### PR TITLE
change project name to api.common

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 	id 'io.freefair.lombok' version '8.11'
 }
 
-group = 'com.courses.common'
+group = 'api.common'
 version = '0.0.1'
 
 java {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'course-common'
+rootProject.name = 'api.common'

--- a/src/main/java/api/common/controller/ErrorResponseFactory.java
+++ b/src/main/java/api/common/controller/ErrorResponseFactory.java
@@ -1,9 +1,9 @@
-package com.courses.common.controller;
+package api.common.controller;
 
-import com.courses.common.exception.BaseException;
-import com.courses.common.exception.CriticalTypeException;
-import com.courses.common.exception.ExceptionInfo;
-import com.courses.common.exception.model.ErrorResponse;
+import api.common.exception.BaseException;
+import api.common.exception.CriticalTypeException;
+import api.common.exception.ExceptionInfo;
+import api.common.exception.model.ErrorResponse;
 import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;

--- a/src/main/java/api/common/controller/GlobalControllerAdvice.java
+++ b/src/main/java/api/common/controller/GlobalControllerAdvice.java
@@ -1,10 +1,10 @@
-package com.courses.common.controller;
+package api.common.controller;
 
-import com.courses.common.exception.BaseException;
-import com.courses.common.exception.CriticalTypeException;
-import com.courses.common.exception.ExceptionInfo;
-import com.courses.common.exception.NonCriticalTypeException;
-import com.courses.common.exception.model.ErrorResponse;
+import api.common.exception.BaseException;
+import api.common.exception.CriticalTypeException;
+import api.common.exception.ExceptionInfo;
+import api.common.exception.NonCriticalTypeException;
+import api.common.exception.model.ErrorResponse;
 import java.util.Optional;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/api/common/exception/BaseException.java
+++ b/src/main/java/api/common/exception/BaseException.java
@@ -1,11 +1,11 @@
-package com.courses.common.exception;
+package api.common.exception;
 
-import static com.courses.common.exception.ExceptionConstants.API_ERROR_MESSAGE;
-import static com.courses.common.exception.ExceptionConstants.HTTP_STATUS;
-import static com.courses.common.exception.ExceptionConstants.KEY_VALUE_SEPARATOR;
-import static com.courses.common.exception.ExceptionConstants.LOG_ERROR_MESSAGE;
-import static com.courses.common.exception.ExceptionConstants.LOG_PARAMS;
-import static com.courses.common.exception.ExceptionConstants.MESSAGE_SEPARATOR;
+import static api.common.exception.ExceptionConstants.API_ERROR_MESSAGE;
+import static api.common.exception.ExceptionConstants.HTTP_STATUS;
+import static api.common.exception.ExceptionConstants.KEY_VALUE_SEPARATOR;
+import static api.common.exception.ExceptionConstants.LOG_ERROR_MESSAGE;
+import static api.common.exception.ExceptionConstants.LOG_PARAMS;
+import static api.common.exception.ExceptionConstants.MESSAGE_SEPARATOR;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/api/common/exception/CriticalTypeException.java
+++ b/src/main/java/api/common/exception/CriticalTypeException.java
@@ -1,4 +1,4 @@
-package com.courses.common.exception;
+package api.common.exception;
 
 /**
  * All the server related exception should extend CriticalTypeException.<br>

--- a/src/main/java/api/common/exception/ExceptionConstants.java
+++ b/src/main/java/api/common/exception/ExceptionConstants.java
@@ -1,4 +1,4 @@
-package com.courses.common.exception;
+package api.common.exception;
 
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;

--- a/src/main/java/api/common/exception/ExceptionInfo.java
+++ b/src/main/java/api/common/exception/ExceptionInfo.java
@@ -1,4 +1,4 @@
-package com.courses.common.exception;
+package api.common.exception;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/api/common/exception/NonCriticalTypeException.java
+++ b/src/main/java/api/common/exception/NonCriticalTypeException.java
@@ -1,4 +1,4 @@
-package com.courses.common.exception;
+package api.common.exception;
 
 /**
  * All the client related exception should extend NonCriticalTypeException.<br>

--- a/src/main/java/api/common/exception/model/ErrorResponse.java
+++ b/src/main/java/api/common/exception/model/ErrorResponse.java
@@ -1,4 +1,4 @@
-package com.courses.common.exception.model;
+package api.common.exception.model;
 
 import java.util.List;
 

--- a/src/main/java/api/common/exception/model/ErrorType.java
+++ b/src/main/java/api/common/exception/model/ErrorType.java
@@ -1,4 +1,4 @@
-package com.courses.common.exception.model;
+package api.common.exception.model;
 
 import lombok.Getter;
 

--- a/src/main/java/api/common/exception/util/ExceptionHelper.java
+++ b/src/main/java/api/common/exception/util/ExceptionHelper.java
@@ -1,9 +1,9 @@
-package com.courses.common.exception.util;
+package api.common.exception.util;
 
-import com.courses.common.exception.BaseException;
-import com.courses.common.exception.CriticalTypeException;
-import com.courses.common.exception.ExceptionInfo;
-import com.courses.common.exception.NonCriticalTypeException;
+import api.common.exception.BaseException;
+import api.common.exception.CriticalTypeException;
+import api.common.exception.ExceptionInfo;
+import api.common.exception.NonCriticalTypeException;
 import java.util.List;
 import java.util.Map;
 import lombok.AccessLevel;


### PR DESCRIPTION
Changing project name from course to api as it can be used across multiple application with any domain dependency.